### PR TITLE
Create library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=EmbAJAX
+version=0.1.0
+author=tfry-git
+maintainer=tfry-git
+sentence=Framework for displays and controls on a web page
+paragraph=Simplistic framework for creating and handling displays and controls on a web page served by an embeddable device (Arduino or other microcontroller with Arduino support).
+category=Communication
+url=https://github.com/tfry-git/EmbAJAX
+architectures=*
+depends=


### PR DESCRIPTION
Add `library.properties`, allowing use in newer Arduino versions.
Library version has been set to `v0.1.0`.

Fixes part of issue #30.