### PR TITLE
Added: connection events

### DIFF
--- a/EmbAJAX.h
+++ b/EmbAJAX.h
@@ -98,6 +98,13 @@ template<size_t NUM> friend class EmbAJAXContainer;
     void handleRequest(EmbAJAXBase** children, size_t num, void (*change_callback)());
 };
 
+/** Connection event type. Used in callback function onConnectionEvent_callback in installPage */
+enum  EmbAjaxConnectionEventType {
+	EmbAjaxConnectionEventConnected,
+	EmbAjaxConnectionEventDisconnected,
+	EmbAjaxConnectionEventMessage,
+};
+
 /** @brief Abstract base class for output drivers/server implementations
  *
  *  Output driver as an abstraction over the server read/write commands.
@@ -121,8 +128,10 @@ public:
     /** Set up the given page to be served on the given path.
      *
      *  @param change_callback See EmbAJAXPage::handleRequest() for details.
+     *  @param onConnectionEvent_callback function that will be called when a client is connected,
+     *                                    all clients are disconnected or when a message is received
      */
-    virtual void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0) = 0;
+    virtual void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0, void (*onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0) = 0;
     /** Insert this hook into loop(). Takes care of the appropriate server calls, if needed. */
     virtual void loopHook() = 0;
 

--- a/EmbAJAX.h
+++ b/EmbAJAX.h
@@ -125,13 +125,21 @@ public:
     virtual void printHeader(bool html) = 0;
     virtual void printContent(const char *content) = 0;
     virtual const char* getArg(const char* name, char* buf, int buflen) = 0;
-    /** Set up the given page to be served on the given path.
+
+    /** Set up the callback function to process connection events
      *
-     *  @param change_callback See EmbAJAXPage::handleRequest() for details.
      *  @param onConnectionEvent_callback function that will be called when a client is connected,
      *                                    all clients are disconnected or when a message is received
      */
-    virtual void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0, void (*onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0) = 0;
+    void setConnectionEventCallback(void (*onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0) {
+        _onConnectionEvent_callback = onConnectionEvent_callback;
+    }
+
+    /** Set up the given page to be served on the given path.
+     *
+     *  @param change_callback See EmbAJAXPage::handleRequest() for details.
+     */
+    virtual void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0) = 0;
     /** Insert this hook into loop(). Takes care of the appropriate server calls, if needed. */
     virtual void loopHook() = 0;
 
@@ -178,6 +186,8 @@ public:
 private:
     uint16_t _revision;
     uint16_t next_revision;
+protected:
+    void (*_onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0;
 };
 
 /** Convenience macro to set up an EmbAJAXPage, without counting the number of elements for the template. See EmbAJAXPage::EmbAJAXPage()

--- a/EmbAJAXOutputDriverESPAsync.h
+++ b/EmbAJAXOutputDriverESPAsync.h
@@ -56,8 +56,7 @@ public:
         _request->arg(name).toCharArray (buf, buflen);
         return buf;
     }
-    void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0, void (*onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0) override {
-        _onConnectionEvent_callback = onConnectionEvent_callback;
+    void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0) override {
         _server->on(path, [=](AsyncWebServerRequest* request) {
              _request = request;
              _response = 0;
@@ -67,7 +66,7 @@ public:
                      connected=true;
                      if (_onConnectionEvent_callback) (*_onConnectionEvent_callback)(EmbAjaxConnectionEventConnected);
                  }
-                 if (onConnectionEvent_callback) (*onConnectionEvent_callback)(EmbAjaxConnectionEventMessage);
+                 if (_onConnectionEvent_callback) (*_onConnectionEvent_callback)(EmbAjaxConnectionEventMessage);
                  page->handleRequest(change_callback);
              } else {  // Page load
                  page->printPage();
@@ -95,7 +94,6 @@ private:
     
     boolean connected=false;
     unsigned long lastmessagetime=0;
-    void (*_onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0;
 };
 
 typedef EmbAJAXOutputDriverESPAsync EmbAJAXOutputDriver;

--- a/EmbAJAXOutputDriverESPAsync.h
+++ b/EmbAJAXOutputDriverESPAsync.h
@@ -56,11 +56,18 @@ public:
         _request->arg(name).toCharArray (buf, buflen);
         return buf;
     }
-    void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0) override {
+    void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0, void (*onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0) override {
+        _onConnectionEvent_callback = onConnectionEvent_callback;
         _server->on(path, [=](AsyncWebServerRequest* request) {
              _request = request;
              _response = 0;
              if (_request->method() == HTTP_POST) {  // AJAX request
+                 lastmessagetime=millis();
+                 if (!connected) {
+                     connected=true;
+                     if (_onConnectionEvent_callback) (*_onConnectionEvent_callback)(EmbAjaxConnectionEventConnected);
+                 }
+                 if (onConnectionEvent_callback) (*onConnectionEvent_callback)(EmbAjaxConnectionEventMessage);
                  page->handleRequest(change_callback);
              } else {  // Page load
                  page->printPage();
@@ -69,11 +76,26 @@ public:
              _request = 0;
         });
     }
-    void loopHook() override {};
+    void loopHook() override {
+        boolean lastconnected = connected;
+        if (millis()>lastmessagetime+2500UL) {
+			connected=false;
+        }
+        if (lastconnected && !connected) {
+			if (_onConnectionEvent_callback) (*_onConnectionEvent_callback)(EmbAjaxConnectionEventDisconnected);
+        }
+    };
+	
+	boolean getConnected() { return connected; }
+    
 private:
     EmbAJAXOutputDriverWebServerClass *_server;
     AsyncWebServerRequest *_request;
     AsyncResponseStream *_response;
+    
+    boolean connected=false;
+    unsigned long lastmessagetime=0;
+    void (*_onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0;
 };
 
 typedef EmbAJAXOutputDriverESPAsync EmbAJAXOutputDriver;

--- a/EmbAJAXOutputDriverGeneric.h
+++ b/EmbAJAXOutputDriverGeneric.h
@@ -58,15 +58,14 @@ public:
         _server->arg(name).toCharArray (buf, buflen);
         return buf;
     }
-    void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0, void (*onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0) override {
-		_onConnectionEvent_callback = onConnectionEvent_callback;
+    void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0) override {
         _server->on(path, [=]() {
              if (_server->method() == HTTP_POST) {  // AJAX request                 
                  if (!connected) {
                      connected=true;
                      if (_onConnectionEvent_callback) (*_onConnectionEvent_callback)(EmbAjaxConnectionEventConnected);
                  }
-                 if (onConnectionEvent_callback) (*onConnectionEvent_callback)(EmbAjaxConnectionEventMessage);
+                 if (_onConnectionEvent_callback) (*_onConnectionEvent_callback)(EmbAjaxConnectionEventMessage);
                  lastmessagetime=millis();
                  page->handleRequest(change_callback);
              } else {  // Page load
@@ -93,7 +92,6 @@ private:
     
     boolean connected=false;
     unsigned long lastmessagetime=0;
-    void (*_onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0;
 };
 
 typedef EmbAJAXOutputDriverGeneric EmbAJAXOutputDriver;

--- a/EmbAJAXOutputDriverGeneric.h
+++ b/EmbAJAXOutputDriverGeneric.h
@@ -58,9 +58,16 @@ public:
         _server->arg(name).toCharArray (buf, buflen);
         return buf;
     }
-    void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0) override {
+    void installPage(EmbAJAXPageBase *page, const char *path, void (*change_callback)()=0, void (*onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0) override {
+		_onConnectionEvent_callback = onConnectionEvent_callback;
         _server->on(path, [=]() {
-             if (_server->method() == HTTP_POST) {  // AJAX request
+             if (_server->method() == HTTP_POST) {  // AJAX request                 
+                 if (!connected) {
+                     connected=true;
+                     if (_onConnectionEvent_callback) (*_onConnectionEvent_callback)(EmbAjaxConnectionEventConnected);
+                 }
+                 if (onConnectionEvent_callback) (*onConnectionEvent_callback)(EmbAjaxConnectionEventMessage);
+                 lastmessagetime=millis();
                  page->handleRequest(change_callback);
              } else {  // Page load
                  page->printPage();
@@ -69,9 +76,24 @@ public:
     }
     void loopHook() override {
         _server->handleClient();
+        
+        boolean lastconnected = connected;
+        if (millis()>lastmessagetime+2500UL) {
+		connected=false;
+        }
+        if (lastconnected && !connected) {
+		if (_onConnectionEvent_callback) (*_onConnectionEvent_callback)(EmbAjaxConnectionEventDisconnected);
+        }
     };
+	
+    boolean getConnected() { return connected; }
+	
 private:
     EmbAJAXOutputDriverWebServerClass *_server;
+    
+    boolean connected=false;
+    unsigned long lastmessagetime=0;
+    void (*_onConnectionEvent_callback)(EmbAjaxConnectionEventType)=0;
 };
 
 typedef EmbAJAXOutputDriverGeneric EmbAJAXOutputDriver;

--- a/examples/ConnectionEvent/ConnectionEvent.ino
+++ b/examples/ConnectionEvent/ConnectionEvent.ino
@@ -33,27 +33,6 @@ MAKE_EmbAJAXPage(page, "EmbAJAX example - Connection events", "",
                  &slider
                 )
 
-void setup() {
-  Serial.begin(115200);
-  
-  // Example WIFI setup as an access point. Change this to whatever suits you, best.
-  WiFi.mode(WIFI_AP);
-  WiFi.softAPConfig (IPAddress (192, 168, 4, 1), IPAddress (0, 0, 0, 0), IPAddress (255, 255, 255, 0));
-  WiFi.softAP("EmbAJAXTest", "12345678");
-
-  Serial.println("EmbAjax connection example");
-  
-  driver.setConnectionEventCallback(onConnectionEvent);
-  
-  // Tell the server to serve our EmbAJAX test page on root
-  // installPage() abstracts over the (trivial but not uniform) WebServer-specific instructions to do so
-  driver.installPage(&page, "/", updateUI);
-  server.begin();
-
-  pinMode(LEDCONNECTIONPIN, OUTPUT);
-
-  last_activity_message = millis();
-}
 
 void updateUI() {
   // Here you can add code to handle the slider events
@@ -85,6 +64,27 @@ void onConnectionEvent(EmbAjaxConnectionEventType event) {
   }
 }
 
+void setup() {
+  Serial.begin(115200);
+  
+  // Example WIFI setup as an access point. Change this to whatever suits you, best.
+  WiFi.mode(WIFI_AP);
+  WiFi.softAPConfig (IPAddress (192, 168, 4, 1), IPAddress (0, 0, 0, 0), IPAddress (255, 255, 255, 0));
+  WiFi.softAP("EmbAJAXTest", "12345678");
+
+  Serial.println("EmbAjax connection example");
+  
+  driver.setConnectionEventCallback(onConnectionEvent);
+  
+  // Tell the server to serve our EmbAJAX test page on root
+  // installPage() abstracts over the (trivial but not uniform) WebServer-specific instructions to do so
+  driver.installPage(&page, "/", updateUI);
+  server.begin();
+
+  pinMode(LEDCONNECTIONPIN, OUTPUT);
+
+  last_activity_message = millis();
+}
 
 void loop() {
   // handle network. loopHook() simply calls server.handleClient(), it can also call the connection callback function, here onConnectionEvent.

--- a/examples/ConnectionEvent/ConnectionEvent.ino
+++ b/examples/ConnectionEvent/ConnectionEvent.ino
@@ -1,0 +1,102 @@
+/* Basic usage example for EmbAJAX library:
+   The example shows the use of connection events, the LED shows the connection state.
+   The LED is blinking when waiting for a connection. When there is connection the LED is switched 
+   off and flashes each time something is received. The web interface only has a slider. 
+
+   Note that ESP boards seems to be no real standard on which pin the builtin LED is on, and
+   there is a very real chance that LED_BUILTIN is not defined, correctly, for your board.
+   If you see no blinking, try changing the LEDPIN define (with an externally connected LED
+   on a known pin being the safest option). Similarly, on and off states are sometimes reversed.
+
+   This example code is in the public domain. */
+
+#include <EmbAJAX.h>
+
+#define LEDCONNECTIONPIN LED_BUILTIN
+#define LED_BRIGHTNESS_ON  LOW
+#define LED_BRIGHTNESS_OFF HIGH
+long last_activity_message;
+
+// Set up web server, and register it with EmbAJAX. Note: EmbAJAXOutputDriverWebServerClass is a
+// convenience #define to allow using the same example code across platforms
+EmbAJAXOutputDriverWebServerClass server(80);
+EmbAJAXOutputDriver driver(&server);
+
+// Define the main elements of interest as variables, so we can access to them later in our sketch.
+EmbAJAXSlider slider("slider", 0, 1000, 100);   // slider, from 0 to 1000, initial value 100
+
+// Define a page (named "page") with our elements of interest, above, interspersed by some uninteresting
+// static HTML. Note: MAKE_EmbAJAXPage is just a convenience macro around the EmbAJAXPage<>-class.
+MAKE_EmbAJAXPage(page, "EmbAJAX example - Connection events", "",
+                 new EmbAJAXStatic("<h1>Control the slider and see the messages on the builtin LED</h1><p>"),
+                 new EmbAJAXStatic("</p><p>Slider: "),
+                 &slider
+                )
+
+void setup() {
+  Serial.begin(115200);
+  
+  // Example WIFI setup as an access point. Change this to whatever suits you, best.
+  WiFi.mode(WIFI_AP);
+  WiFi.softAPConfig (IPAddress (192, 168, 4, 1), IPAddress (0, 0, 0, 0), IPAddress (255, 255, 255, 0));
+  WiFi.softAP("EmbAJAXTest", "12345678");
+
+  Serial.println("EmbAjax connection example");
+
+  // Tell the server to serve our EmbAJAX test page on root
+  // installPage() abstracts over the (trivial but not uniform) WebServer-specific instructions to do so
+  driver.installPage(&page, "/", updateUI, onConnectionEvent);
+  server.begin();
+
+  pinMode(LEDCONNECTIONPIN, OUTPUT);
+
+  last_activity_message = millis();
+}
+
+void updateUI() {
+  // Here you can add code to handle the slider events
+
+  Serial.print("updateUI slider value=");
+  Serial.println(slider.intValue());
+}
+
+void onConnectionEvent(EmbAjaxConnectionEventType event) {
+  switch (event)
+  {
+    case EmbAjaxConnectionEventConnected:
+      Serial.println("Connected");
+      digitalWrite(LEDCONNECTIONPIN, LED_BRIGHTNESS_OFF);
+      break;
+
+    case EmbAjaxConnectionEventDisconnected:
+      Serial.println("Disconnected");
+      break;
+
+    case EmbAjaxConnectionEventMessage:
+      Serial.println("Message received");
+      digitalWrite(LEDCONNECTIONPIN, LED_BRIGHTNESS_ON);
+      last_activity_message = millis();
+      break;
+
+    default:
+      break;
+  }
+}
+
+
+void loop() {
+  // handle network. loopHook() simply calls server.handleClient(), it can also call the connection callback function, here onConnectionEvent.
+  driver.loopHook();
+
+  if (driver.getConnected()) {
+    // when something is received, the LED will be switched on in onConnectionEvent, here it is turned off after 1 ms
+    if (millis() > last_activity_message + 1)
+    {
+      digitalWrite(LEDCONNECTIONPIN, LED_BRIGHTNESS_OFF);
+    }
+  }
+  else {
+    // In case there is no connection, let the LED blink
+    digitalWrite(LEDCONNECTIONPIN, (millis() % 1000) > 500 ? LED_BRIGHTNESS_ON : LED_BRIGHTNESS_OFF);
+  }
+}

--- a/examples/ConnectionEvent/ConnectionEvent.ino
+++ b/examples/ConnectionEvent/ConnectionEvent.ino
@@ -42,10 +42,12 @@ void setup() {
   WiFi.softAP("EmbAJAXTest", "12345678");
 
   Serial.println("EmbAjax connection example");
-
+  
+  driver.setConnectionEventCallback(onConnectionEvent);
+  
   // Tell the server to serve our EmbAJAX test page on root
   // installPage() abstracts over the (trivial but not uniform) WebServer-specific instructions to do so
-  driver.installPage(&page, "/", updateUI, onConnectionEvent);
+  driver.installPage(&page, "/", updateUI);
   server.begin();
 
   pinMode(LEDCONNECTIONPIN, OUTPUT);

--- a/examples/ConnectionEvent/ConnectionEvent.ino
+++ b/examples/ConnectionEvent/ConnectionEvent.ino
@@ -12,6 +12,8 @@
 
 #include <EmbAJAX.h>
 
+void onConnectionEvent(EmbAjaxConnectionEventType event);
+
 #define LEDCONNECTIONPIN LED_BUILTIN
 #define LED_BRIGHTNESS_ON  LOW
 #define LED_BRIGHTNESS_OFF HIGH


### PR DESCRIPTION
This PR adds functionality with connection events using a callback system.

**Problem**
I try to use this library for workshops in which motor equipped devices are controlled (zeppelin, hovercraft, ...). In such cases it is important to have an indication in the device to see if the connection is working or not: motors should be switched off when connection is lost for safety reasons. Also it is interesting to have a LED indicator showing if a device has a connection and is receiving data. Especially in workshops with 10 or 20 devices, it is helpfull when things are not working as expected.

**Solution**
A callback mechanism is added for receiving connection events. Supported events are 
- EmbAjaxConnectionEventConnected: when a browser is connected
- EmbAjaxConnectionEventDisconnected: when no browser is connected anymore
- EmbAjaxConnectionEventMessage: each time some data is received from the browser

The state is connected, as long as at least one device is connected (and a browser session is active). Detection of the connection is done by checking heartbeat (every second).

An example is added with a led connection indicator.